### PR TITLE
fix: use localStorageFactory for LOCAL_STORAGE token

### DIFF
--- a/lib/src/storage-providers.ts
+++ b/lib/src/storage-providers.ts
@@ -33,5 +33,5 @@ export function localStorageFactory(): StorageService {
 /** Injection token for the local storage service. */
 export const LOCAL_STORAGE = new InjectionToken<StorageService>(
     'LOCAL_STORAGE',
-    { providedIn: 'root', factory: sessionStorageFactory }
+    { providedIn: 'root', factory: localStorageFactory }
 );


### PR DESCRIPTION
#9 Fix issue, with incorrect storage usage (using session storage for LOCAL_STORAGE token